### PR TITLE
V1.1.1

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,16 +6,21 @@ import (
 	"strings"
 )
 
+// AuthError contains details regarding any authorization errors
+// encountered while attempting to read or parse a PASETO token
 type AuthError struct {
 	Message string `json:"message,omitempty"`
 	Status  int    `json:"status"`
 	Title   string `json:"title"`
 }
 
+// Error provides details about the error
 func (err AuthError) Error() string {
 	return err.Message
 }
 
+// AuthorizationMissingError is for when the Authorization header
+// is not present in the request
 func AuthorizationMissingError() *AuthError {
 	return &AuthError{
 		Message: "Authorization header is missing",
@@ -24,6 +29,8 @@ func AuthorizationMissingError() *AuthError {
 	}
 }
 
+// BearerTokenError is for when the Authorization header is not
+// properly formatted or does not contain an actual Bearer value
 func BearTokenError() *AuthError {
 	return &AuthError{
 		Message: "Bearer token is missing or improperly formatted",
@@ -32,6 +39,8 @@ func BearTokenError() *AuthError {
 	}
 }
 
+// NotAuthorizedError is for when the provided PASETO token is not
+// allowed access due to a scope validation failure
 func NotAuthorizedError(scopes []string) *AuthError {
 	return &AuthError{
 		Message: fmt.Sprintf(
@@ -42,6 +51,7 @@ func NotAuthorizedError(scopes []string) *AuthError {
 	}
 }
 
+// TokenParseError is for when the PASETO token can't be parsed properly
 func TokenParseError(m string) *AuthError {
 	return &AuthError{
 		Message: m,
@@ -50,6 +60,8 @@ func TokenParseError(m string) *AuthError {
 	}
 }
 
+// TokenValidationError occurs when the PASETO token is
+// expired or invalid and no scopes are being checked
 func TokenValidationError(m string) *AuthError {
 	return &AuthError{
 		Message: m,

--- a/readme.md
+++ b/readme.md
@@ -62,9 +62,10 @@ handler := middleware.NewTokenHandler(symmetricKey)
 
 The following is a reference to the PASETO specification protocol versions and encryption / signing details:
 
- | local | public
-v1| AES-256-CTR + HMAC-SHA384 | 2048-bit RSA public key
-v2| XChaCha20-Poly1305 | Ed25519
+| version | local                     | public                  |
+|---------|---------------------------|-------------------------|
+|    v1   | AES-256-CTR + HMAC-SHA384 | 2048-bit RSA public key |
+|    v2   | XChaCha20-Poly1305        | Ed25519                 |
 
 The PASETO bearer tokens are expected to be provided via the inbound request in the `Authorization` header:
 

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,9 @@ func main() {
   th := middleware.NewTokenHandler([]byte(symmetricKey), publicKey)
 
   // validate with a specified claim
-  ge.GET("/foos", th.ScopeAuthorization("foos", "read", "modify"), func (ctx *gin.Context) {
-    // middleware will check the token to see if there is a claim with a dictionary key named 
-    // "foos" with a value of either "read" or "modify"
+  ge.GET("/foos", th.ScopeAuthorization("cool-scope", "another-scope", "yet-another-scope"), func (ctx *gin.Context) {
+    // middleware will check the token to see if there is a scope that matches any of the
+    // allowed scopes supplied to the ScopeAuthorization function
     ctx.IndentedJSON(http.StatusOK, gin.H{
       "foos": "yeah!"
     })
@@ -44,5 +44,108 @@ func main() {
   })
 
   ge.Run(":8080")
+}
+```
+
+### TokenHandler
+
+The token handler middleware can be initialized with public and/or symmetric keys in order to validate and extract JWT details from PASETO tokens that are provided as Bearer tokens on API requests. 
+
+If the API only requires handling of `v2` PASETO local tokens, the token handler can be initialized with a single 32 byte symmetric key (a `string` or `[]byte` value). If `v2` public, `v2` local and `v1` public keys all require validation, then the token handler can be created with an Ed25519 public key, a 32 byte symmetric key (`string` or `[]byte`) and an RSA public key.
+
+For example, the following creates a v2 private PASETO token parser
+
+```go
+symmetricKey := "brozeph, where is my secret key?" // 32 bytes
+handler := middleware.NewTokenHandler(symmetricKey)
+```
+
+The following is a reference to the PASETO specification protocol versions and encryption / signing details:
+
+ | local | public
+v1| AES-256-CTR + HMAC-SHA384 | 2048-bit RSA public key
+v2| XChaCha20-Poly1305 | Ed25519
+
+The PASETO bearer tokens are expected to be provided via the inbound request in the `Authorization` header:
+
+```http
+GET /v1/things/1234 HTTP/1.1
+Authorization: Bearer v2.private.HkM8o... // <- PASETO token
+```
+
+#### Middleware
+
+Once the `TokenHandler` has been created, it can be used to register middleware on a per API endpoint or resource basis.
+
+Take, for example, the API resource below... ``GET` requests to `/v1/things` is being handled by a function called `GetThings`. 
+
+```go
+func RegisterAPIResources(c *gin.Engine, bs interfaces.IThingsController) {
+  c.GET("/v1/things", bs.GetThings)
+}
+```
+
+In order to secure the `GET` request to `/v1/things`, a `TokenHandler`, like the one created earlier, can perform the authorization in middleware with a minor tweak to the above method:
+
+```go
+func RegisterAPIResources(c *gin.Engine, th *middleware.TokenHandler, bs interfaces.IThingsController) {
+  c.GET("/v1/things", th.ScopeAuthorization("things-read"), bs.GetThings)
+}
+```
+
+The middleware now looks for a valid (non-expired, properly formatted and parseable) PASETO token containing the scope `things-read`. In the event there is a problem, the middleware will register the error in the `*gin.Context` and abort the request. Otherwise, the request will succeed and the `GetThings` method will be called to handle the request.
+
+##### Errors
+
+The middleware will register errors of type `AuthError`. The `AuthError` contains 3 fields:
+
+* `Message` - a string message specific to the error
+* `Status` - an Int representing the HTTP status for unauthorized (401)
+* `Title` - a string value for the type of error, "Unauthorized"
+
+The following is an example middleware error reporter that can be used to properly output the error and status to the request when there is an authorization problem.
+
+```go
+func errorReporter(ctx *gin.Context) {
+  ctx.Next()
+  detectedErrs := ctx.Errors.ByType(gin.ErrorTypeAny)
+
+  if len(detectedErrs) == 0 {
+    return
+  }
+
+  // handle the last error
+  err := detectedErrs.Last().Err
+  switch err := err.(type) {
+  case *middleware.AuthError:
+    ctx.IndentedJSON(err.Status, err)
+    ctx.Abort()
+  case *myerrors.MyError:
+    // handle custom errors
+  default:
+    // do some other processing here...
+  }
+}
+```
+
+##### JSON Token
+
+The data stored in the PASETO is a JSON Token. This token contains scopes and claims that may be useful for subsequent API route handling, so the unencrypted JSON Token data is added to the `*gin.Context` per request.
+
+```go
+func (c APIController) GetThings(ctx *gin.Context) {
+  // the middleware has already authorized this request...
+  // retrieve the token...
+  jwt := ctx.Get("jwt")(paseto.JSONToken)
+
+  // pull a custom claim from the token 
+  // if it is expected to be there...
+  thingOwner, err := jwt.Get("thingOwner")
+  if err != nil {
+    ctx.Error(errors.New("where's mah claim?!?!"))
+    return
+  }
+
+  // do some stuff with the thingOwner...
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ The token handler middleware can be initialized with public and/or symmetric key
 
 If the API only requires handling of `v2` PASETO local tokens, the token handler can be initialized with a single 32 byte symmetric key (a `string` or `[]byte` value). If `v2` public, `v2` local and `v1` public keys all require validation, then the token handler can be created with an Ed25519 public key, a 32 byte symmetric key (`string` or `[]byte`) and an RSA public key.
 
-For example, the following creates a v2 private PASETO token parser
+For example, the following creates a v2 local PASETO token parser
 
 ```go
 symmetricKey := "brozeph, where is my secret key?" // 32 bytes

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ The PASETO bearer tokens are expected to be provided via the inbound request in 
 
 ```http
 GET /v1/things/1234 HTTP/1.1
-Authorization: Bearer v2.private.HkM8o... // <- PASETO token
+Authorization: Bearer v2.local.HkM8o... // <- PASETO token
 ```
 
 #### Middleware

--- a/tokenHandler.go
+++ b/tokenHandler.go
@@ -15,11 +15,17 @@ import (
 
 var bearerRE = regexp.MustCompile(`(?i)Bearer `)
 
+// TokenHandler provides middleware for validating and reading the
+// details from a PASETO token provided as a bearer token on the
+// request
 type TokenHandler struct {
 	publicKeyMap map[paseto.Version]crypto.PublicKey
 	symmetricKey []byte
 }
 
+// NewTokenHandler creates a new middleware handler with the specified keys
+// for properly verifying or decrypting v1 and v2 PASETO tokens provided
+// as bearer tokens within the Authorization header of a request
 func NewTokenHandler(keys ...interface{}) TokenHandler {
 	var symmetricKey []byte
 	keyMap := map[paseto.Version]crypto.PublicKey{}

--- a/tokenHandler.go
+++ b/tokenHandler.go
@@ -1,3 +1,5 @@
+// Package middleware provides handlers for PASETO token verification
+// and authorization for gin-gonic/gin API servers
 package middleware
 
 import (
@@ -73,6 +75,8 @@ func (th TokenHandler) ScopeAuthorization(allowedScopes ...string) gin.HandlerFu
 	}
 }
 
+// ValidToken provides gin middleware that ensures a bearer token in the
+// request has valid and has not expired.
 func (th TokenHandler) ValidToken() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		if _, err := th.readAuthorization(ctx); err != nil {
@@ -117,6 +121,8 @@ func (th TokenHandler) readAuthorization(ctx *gin.Context) (paseto.JSONToken, er
 
 	// validate the date
 	if err := jwt.Validate(); err != nil {
+		// set the token on the context for subsequent use
+		ctx.Set("jwt", jwt)
 		return jwt, TokenValidationError(err.Error())
 	}
 


### PR DESCRIPTION
Mostly documentation, but also adding the `jwt` to the `gin.Context` after it is parsed/decrypted for subsequent use by any consuming APIs to retrieve claims.